### PR TITLE
Determine aws-cdk version from package.json

### DIFF
--- a/lib/aws.bash
+++ b/lib/aws.bash
@@ -233,6 +233,8 @@ aws_set_service_account_config() {
   [[ -z ${AWS_CONFIG_BASEDIR} ]] && AWS_CONFIG_BASEDIR=~/.aws
   if [[ -n ${SA_ACCOUNT_LIST} ]]; then
     check_command aws || install_awscli
+
+
     mkdir -p "${AWS_CONFIG_BASEDIR}"
     info "Start creation of ${AWS_CONFIG_BASEDIR}/credentials"
     {
@@ -391,9 +393,6 @@ aws_cloudfront_invalidate() {
 #######################################
 aws_cdk_determine_version() {
   # Determine the aws-cdk version to use
-  npx npm list aws-cdk || true
-  npx npm list aws-cdk-lib || true
-
   if npx npm list aws-cdk >/dev/null 2>&1; then
     local aws_cdk_pkg=$(npx npm list aws-cdk)
     AWS_CDK_VERSION="${aws_cdk_pkg##*@}"

--- a/lib/aws.bash
+++ b/lib/aws.bash
@@ -479,7 +479,6 @@ aws_cdk_deploy() {
     else
       warning "Could not determine aws-cdk version from package.json, using ${AWS_CDK_VERSION:-1.91.0}"
     fi
-    warning "Could not determine aws-cdk version from package.json, using ${AWS_CDK_VERSION:-1.91.0}"
   fi
 
   # Set correct profile for role on destination account to be assumed

--- a/lib/aws.bash
+++ b/lib/aws.bash
@@ -468,6 +468,14 @@ aws_cdk_deploy() {
     info "Found aws-cdk version in package.json: ${AWS_CDK_VERSION}"
     info "Will use this version to deploy the infrastructure"
   else
+    if npm list aws-cdk-lib > /dev/null 2>&1; then
+      local aws_cdk_pkg=$(npm list aws-cdk-lib)
+      AWS_CDK_VERSION="${aws_cdk_pkg##*@}"
+      info "Found aws-cdk version in package.json: ${AWS_CDK_VERSION}"
+      info "Will use this version to deploy the infrastructure"
+    else
+      warning "Could not determine aws-cdk version from package.json, using ${AWS_CDK_VERSION:-1.91.0}"
+    fi
     warning "Could not determine aws-cdk version from package.json, using ${AWS_CDK_VERSION:-1.91.0}"
   fi
 

--- a/lib/aws.bash
+++ b/lib/aws.bash
@@ -462,6 +462,9 @@ aws_cdk_deploy() {
   fi
 
   # Determine the aws-cdk version to use
+  npm list aws-cdk
+  npm list aws-cdk-lib
+
   if npm list aws-cdk > /dev/null 2>&1; then
     local aws_cdk_pkg=$(npm list aws-cdk)
     AWS_CDK_VERSION="${aws_cdk_pkg##*@}"

--- a/lib/aws.bash
+++ b/lib/aws.bash
@@ -462,8 +462,8 @@ aws_cdk_deploy() {
   fi
 
   # Determine the aws-cdk version to use
-  npm list aws-cdk
-  npm list aws-cdk-lib
+  npm list aws-cdk || true
+  npm list aws-cdk-lib || true
 
   if npm list aws-cdk > /dev/null 2>&1; then
     local aws_cdk_pkg=$(npm list aws-cdk)

--- a/lib/aws.bash
+++ b/lib/aws.bash
@@ -462,17 +462,17 @@ aws_cdk_deploy() {
   fi
 
   # Determine the aws-cdk version to use
-  npm list aws-cdk || true
-  npm list aws-cdk-lib || true
+  npx npm list aws-cdk || true
+  npx npm list aws-cdk-lib || true
 
-  if npm list aws-cdk > /dev/null 2>&1; then
-    local aws_cdk_pkg=$(npm list aws-cdk)
+  if npx npm list aws-cdk > /dev/null 2>&1; then
+    local aws_cdk_pkg=$(npx npm list aws-cdk)
     AWS_CDK_VERSION="${aws_cdk_pkg##*@}"
     info "Found aws-cdk version in package.json: ${AWS_CDK_VERSION}"
     info "Will use this version to deploy the infrastructure"
   else
-    if npm list aws-cdk-lib > /dev/null 2>&1; then
-      local aws_cdk_pkg=$(npm list aws-cdk-lib)
+    if npx npm list aws-cdk-lib > /dev/null 2>&1; then
+      local aws_cdk_pkg=$(npx npm list aws-cdk-lib)
       AWS_CDK_VERSION="${aws_cdk_pkg##*@}"
       info "Found aws-cdk version in package.json: ${AWS_CDK_VERSION}"
       info "Will use this version to deploy the infrastructure"

--- a/lib/install.bash
+++ b/lib/install.bash
@@ -94,6 +94,11 @@ install_awscli() {
   else
     info "${FUNCNAME[0]} - awscli already installed"
   fi
+
+  if ! command -v aws > /dev/null 2>&1; then
+    fail "The aws cli is not found after installation. Please restart the pipeline. Contact your administrator if this continues to happen"
+  fi
+
 }
 
 install_zip() {


### PR DESCRIPTION
No need to specify `AWS_CDK_VERSION` anymore. It will we used in case the version cannot be determined otherwise.