### PR TITLE
feature: add 2 functions to aws library, required to manage project's SSM parameters

### DIFF
--- a/lib/bitbucket.bash
+++ b/lib/bitbucket.bash
@@ -307,8 +307,6 @@ bb_start_pipeline_for_repo() {
     fi
   fi
 
-
-
   cat > /curldata.commithash << EOF
 {
   "target": {


### PR DESCRIPTION
Add 2 functions to aws library, required to manage project's SSM parameters

* `aws_delete_ssm_parameter`
* `aws_get_ssm_parameter_by_path`